### PR TITLE
Correctly read 0xff from stdin

### DIFF
--- a/npiet.c
+++ b/npiet.c
@@ -2131,7 +2131,7 @@ piet_action (int c_col, int a_col, int num_cells, char *msg)
 	tprintf ("info: cannot read char from stdin; reason: %s\n",
 		 strerror (errno));
       } else {
-	stack [num_stack++] = c % 0xff;
+	stack [num_stack++] = c & 0xff;
       }
       tdump_stack ();
 


### PR DESCRIPTION
`% 0xff' wrongly modifies 0xff to 0x00.

Test program: http://shinh.skr.jp/t/echo_1b.png

$ echo -ne "\xff" | ./npiet -q echo_1b.png | xxd
00000000: ff                                       .
