### PR TITLE
Remove <sys/malloc.h> for modern distro's and OS's

### DIFF
--- a/npiet-foogol.c
+++ b/npiet-foogol.c
@@ -150,7 +150,6 @@ char *version = "v1.3";
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/malloc.h>
 #include <limits.h>
 #include <time.h>
 

--- a/npiet-foogol.y
+++ b/npiet-foogol.y
@@ -43,7 +43,6 @@ char *version = "v1.3";
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/malloc.h>
 #include <limits.h>
 #include <time.h>
 


### PR DESCRIPTION
This pull request removed sys/malloc.h from 2 files in order for modern distro's to not fail during compilation.